### PR TITLE
Compiler changed to clang in windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ set(SOURCES Network.cpp DD.cpp grb.cpp DDSolver.cpp NodeExplorer.cpp OriginalPro
 add_executable(SGUFP_Solver main.cpp ${SOURCES})
 
 # preprocessor macros.
-add_compile_definitions(MAX_WIDTH=120)
+add_compile_definitions(MAX_WIDTH=300)
 
 
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
@@ -49,11 +49,9 @@ if (UNIX)
     add_library(gurobi110 SHARED IMPORTED)
     set_property(TARGET gurobi110 PROPERTY IMPORTED_LOCATION "${GUROBI_LIB}libgurobi110.so")
 
-
     add_compile_definitions(SOLVER_STATS)
     target_compile_options(SGUFP_Solver PRIVATE -Wall -Wextra -pg -g -pthread) # add -O3 flag in final phase. -Wunused
     target_link_options(SGUFP_Solver PRIVATE -pg -g -pthread)
-
 #    target_compile_options(SGUFP_Solver PRIVATE -Wall -Wextra -Wpedantic -Werror -Wshadow -Wnull-dereference)
 #    target_compile_options(SGUFP_Solver PRIVATE -Wuseless-cast -Wduplicated-cond -Wduplicated-branches -Wold-style-cast)
 #    target_compile_options(SGUFP_Solver PRIVATE -fsanitize=pointer-subtract -fsanitize=address)
@@ -67,13 +65,14 @@ if (UNIX)
     target_link_libraries(SGUFP_Solver PRIVATE gurobi110)
     target_include_directories(SGUFP_Solver PRIVATE ${GUROBI_INCLUDE})
 
+#    message(STATUS "General FLAGS: ${CMAKE_CXX_FLAGS}")
+    message(STATUS "RELEASE FLAGS: ${CMAKE_CXX_FLAGS_RELEASE}")
+    message(STATUS "DEBUG FLAGS: ${CMAKE_CXX_FLAGS_DEBUG}")
+    message(STATUS "RELWITHDEBINFO FLAGS: ${CMAKE_CXX_FLAGS_RELWITHDEBINFO}")
 
-    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -DDEBUG")
-    set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} -fno-omit-frame-pointer")
-    message(STATUS "${CMAKE_CXX_FLAGS_RELWITHDEBINFO}")
 
     # test targets
-    if (CMAKE_BUILD_TYPE STREQUAL "Debug")
+    if(CMAKE_BUILD_TYPE STREQUAL "Debug")
         add_executable(tests2 tests/tests.cpp ${SOURCES}
                 tests/test_utils.h)
         target_link_libraries(tests2 gurobi_c++ gurobi110 GTest::gtest_main)
@@ -114,18 +113,14 @@ elseif(WIN32)
     message(STATUS "C++ compiler: ${CMAKE_CXX_COMPILER}")
     message(STATUS "C++ compiler version: ${CMAKE_CXX_COMPILER_VERSION}")
 
-
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /openmp /openmp:llvm")
-
-    if (MSVC AND MT)
-        set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /MT /openmp")
-        set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /MTd /openmp")
-        set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} /MT /openmp")
-        set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} /MTd /openmp")
-    endif()
+#    if (MSVC AND MT)
+#        set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /MT")
+#        set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /MTd")
+#        set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} /MT")
+#        set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} /MTd")
+#    endif()
     # flag specific for Dr Memory
-    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /Zi /Oy- /MTd /openmp /openmp:llvm")
-    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /openmp /openmp:llvm")
+#    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /Zi /Oy- /MTd")
 #    message(STATUS "${CMAKE_CXX_FLAGS_DEBUG}")
     find_package(GUROBI REQUIRED)
 

--- a/FindGUROBI.cmake
+++ b/FindGUROBI.cmake
@@ -9,7 +9,7 @@ find_library(GUROBI_LIBRARY
     PATH_SUFFIXES lib)
 
 if(CXX)
-    if(MSVC)
+#    if(MSVC)
         set(MSVC_YEAR "2017")
         
         if(MT)
@@ -26,13 +26,13 @@ if(CXX)
             NAMES gurobi_c++${M_FLAG}d${MSVC_YEAR}
             HINTS ${GUROBI_DIR} $ENV{GUROBI_HOME}
             PATH_SUFFIXES lib)
-    else()
-        find_library(GUROBI_CXX_LIBRARY
-            NAMES gurobi_c++
-            HINTS ${GUROBI_DIR} $ENV{GUROBI_HOME}
-            PATH_SUFFIXES lib)
-        set(GUROBI_CXX_DEBUG_LIBRARY ${GUROBI_CXX_LIBRARY})
-    endif()
+#    else()
+#        find_library(GUROBI_CXX_LIBRARY
+#            NAMES gurobi_c++
+#            HINTS ${GUROBI_DIR} $ENV{GUROBI_HOME}
+#            PATH_SUFFIXES lib)
+#        set(GUROBI_CXX_DEBUG_LIBRARY ${GUROBI_CXX_LIBRARY})
+#    endif()
 endif()
 
 include(FindPackageHandleStandardArgs)


### PR DESCRIPTION
Compiler changed to Clang in Windows Make.

Todo: Change compiler to Clang in Linux make.